### PR TITLE
Bug in setup.py related to Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ PACKAGES = ['csu_radartools']
 
 if USE_CYTHON:
     ext = '.pyx'
-    extensions = [Extension(PACKAGES[0]+'/calc_kdp_ray_fir',
+    extensions = [Extension(PACKAGES[0]+'.calc_kdp_ray_fir',
                   [PACKAGES[0]+'/calc_kdp_ray_fir'+ext])]
 else:
     ext = '.f'


### PR DESCRIPTION
This should fix a bug in setup.py related to how the module is named for cython. I tested on python 3.6 for OS X. You will probably want to test other platforms.