### PR TITLE
Fix: deprecated `np.float` in ML calculation

### DIFF
--- a/csu_radartools/csu_fhc_melt.py
+++ b/csu_radartools/csu_fhc_melt.py
@@ -213,7 +213,7 @@ def get_ml_ppi(fh, dz, height, expected_ML,
             npts = len(np.ravel(whsec))
             # print(npts)
             ML_num_sector = len(ML_sector)
-            per_ML = np.float(ML_num_sector)/npts*100.
+            per_ML = float(ML_num_sector)/npts*100.
             # print('ML number in sector', ML_num_sector,
             #       'percent of sector', per_ML)
             # print('Mean dz in ML', np.nanmean(dz[wh_sector1]))


### PR DESCRIPTION
This was a quicker fix than I thought. 😄 

- [x] Replaced `np.float` with `float` in `per_ML` calculation in file `csu_fhc_melt.py` to address deprecation in NumPy (1.20+). 
- [x] Confirmed that this was the only instance of deprecated `np.float, np.int, np.long`, in the codebase. 
- [x] This will close the issue #73.