### PR TITLE
FIX: deprecated scipy.ndimage warning (minor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.os }}-python-${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gfortran python3-dev build-essential
+          gfortran --version
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install cython pytest
+          pip install -r requirements.txt
+
+      - name: Build and Install csu_radartools
+        run: |
+          python setup.py build_ext --inplace
+          python setup.py install
+
+      - name: Run Tests
+        run: |
+          pytest tests/
+
+

--- a/continuous_integration/environment-ci.yml
+++ b/continuous_integration/environment-ci.yml
@@ -1,0 +1,12 @@
+name: csu-radartools-dev
+channels:
+  - conda-forge
+dependencies:
+  - numpy
+  - pandas
+  - scipy
+  - matplotlib
+  - cython
+  - setuptools  # For building and installing the package
+  - pytest      # For running tests
+

--- a/csu_radartools/csu_misc.py
+++ b/csu_radartools/csu_misc.py
@@ -15,7 +15,7 @@ Lang et al. (2007; JCLIM) - Insect filter
 from __future__ import division
 import numpy as np
 from warnings import warn
-from scipy.ndimage.measurements import label
+from scipy.ndimage import label
 
 VERSION = '1.3'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+pandas
+scipy
+matplotlib
+cython
+


### PR DESCRIPTION
fixed the following deprecation warning 

```
DeprecationWarning: Please use `scipy.ndimage.some_function` instead of `scipy.ndimage.some_module.some_function`
```